### PR TITLE
Restore title bar styling for AttrConnector

### DIFF
--- a/attr_connector.py
+++ b/attr_connector.py
@@ -285,7 +285,7 @@ class TitleBar(QtWidgets.QWidget):
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
         self.setStyleSheet(
             "background-color: %s; border-top-left-radius:12px; border-bottom-left-radius:0px;"
-            " border-top-right-radius:0px; border-bottom-right-radius:0px;" % TITLE_BG_RGBA
+            " border-top-right-radius:12px; border-bottom-right-radius:0px;" % TITLE_BG_RGBA
         )
         lay = QtWidgets.QHBoxLayout(self)
         lay.setContentsMargins(18, 8, 8, 8)
@@ -996,11 +996,11 @@ class AttrConnectorWindow(QtWidgets.QMainWindow):
         ol.setSpacing(0)
         panel = QtWidgets.QFrame()
         panel.setStyleSheet(
-            "QFrame{ background:%s; border:1px solid %s; border-top-left-radius:12px; border-top-right-radius:0px; border-bottom-left-radius:12px; border-bottom-right-radius:12px; }"
+            "QFrame{ background:%s; border:1px solid %s; border-top-left-radius:12px; border-top-right-radius:12px; border-bottom-left-radius:12px; border-bottom-right-radius:12px; }"
             % (PANEL_BG_RGBA, PANEL_BORDER)
         )
         pl = QtWidgets.QVBoxLayout(panel)
-        pl.setContentsMargins(0,0,8,8)
+        pl.setContentsMargins(0,0,0,8)
         pl.setSpacing(6)
         self.title = TitleBar(self, "Attribute Connector")
         pl.addWidget(self.title)


### PR DESCRIPTION
## Summary
- restore the rounded top-right corners for the title bar and outer panel
- extend the custom title bar across the window by removing the right-side inset margin

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da7e02bef48327bfc35fa196bd1f98