### PR TITLE
Align picker title bar margins

### DIFF
--- a/attr_connector.py
+++ b/attr_connector.py
@@ -560,7 +560,7 @@ class AttributePickerDialog(QtWidgets.QDialog):
         outer.addWidget(panel)
 
         panel_layout = QtWidgets.QVBoxLayout(panel)
-        panel_layout.setContentsMargins(0,0,8,8)
+        panel_layout.setContentsMargins(12,0,12,8)
         panel_layout.setSpacing(6)
 
         self.title_bar = TitleBar(self, "Pick Attribute")


### PR DESCRIPTION
## Summary
- adjust the attribute picker panel layout margins to match the updated title bar styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da9c713fc88327b78fa76c88374666