### PR TITLE
Increase message dialog width

### DIFF
--- a/attr_connector.py
+++ b/attr_connector.py
@@ -320,6 +320,7 @@ class StyledMessageDialog(QtWidgets.QDialog):
         self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.Dialog)
         self.setAttribute(QtCore.Qt.WA_TranslucentBackground, True)
         self.setModal(True)
+        self.setMinimumWidth(360)
 
         outer = QtWidgets.QVBoxLayout(self)
         outer.setContentsMargins(10, 10, 10, 10)


### PR DESCRIPTION
## Summary
- set a minimum width on the styled message dialog so the content area feels less cramped

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dab91634fc8327b52ce26729405d95