### PR TITLE
Allow disconnecting targets without a selected source

### DIFF
--- a/attr_connector.py
+++ b/attr_connector.py
@@ -1186,7 +1186,7 @@ class AttrConnectorWidget(QtWidgets.QWidget):
                     if not c or "." not in c:
                         continue
                     node, attr = c.split(".", 1)
-                    if node != src:
+                    if src and node != src:
                         continue
                     if sattr and sattr != "none" and attr != sattr:
                         continue
@@ -1246,6 +1246,16 @@ class AttrConnectorWidget(QtWidgets.QWidget):
                 if sattr == "none":
                     sattr = ""
                 pairs.append((src, sattr, tgt, tattr))
+            return pairs
+
+        # with no explicit source rows, disconnect everything driving the targets
+        if not unique_src_objs:
+            for j in range(tgt_count):
+                tgt = tgt_objs[j]
+                tattr = tgt_attrs[j]
+                if not tgt or not tattr or tattr == "none":
+                    continue
+                pairs.append(("", "", tgt, tattr))
             return pairs
 
         # otherwise match rows pair-wise


### PR DESCRIPTION
## Summary
- allow the disconnect action to operate even when no source rows are provided
- treat empty source fields as wildcards so all incoming connections to the target are removed

## Testing
- python -m compileall attr_connector.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbf759cfc8327abad319557e0394c